### PR TITLE
Add prompt template support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ message meets a specified criterion.
 - **AI classification rule** – adds the "AI classification" term with
   `matches` and `doesn't match` operators.
 - **Configurable endpoint** – set the classification service URL on the options page.
+- **Prompt templates** – choose between several model formats or provide your own custom template.
 - **Filter editor integration** – patches Thunderbird's filter editor to accept
   text criteria for AI classification.
 - **Result caching** – avoids duplicate requests for already-evaluated messages.

--- a/_locales/en-US/messages.json
+++ b/_locales/en-US/messages.json
@@ -4,5 +4,14 @@
   "doesntMatch": { "message": "doesn't match" },
   "options.title": { "message": "AI Filter Options" },
   "options.endpoint": { "message": "Endpoint" },
+  "options.template": { "message": "Prompt template" },
+  "options.customTemplate": { "message": "Custom template" },
+  "options.systemInstructions": { "message": "System instructions" },
+  "options.reset": { "message": "Reset to default" },
+  "options.placeholders": { "message": "Placeholders: {{system}}, {{email}}, {{operator}}, {{query}}" },
+  "template.openai": { "message": "OpenAI / ChatML" },
+  "template.qwen": { "message": "Qwen" },
+  "template.mistral": { "message": "Mistral" },
+  "template.custom": { "message": "Custom" },
   "options.save": { "message": "Save" }
 }

--- a/background.js
+++ b/background.js
@@ -14,7 +14,7 @@
 console.log("[ai-filter] background.js loaded – ready to classify");
 (async () => {
     try {
-        const store = await browser.storage.local.get(["endpoint"]);
+        const store = await browser.storage.local.get(["endpoint", "templateName", "customTemplate", "customSystemPrompt"]);
         await browser.aiFilter.initConfig(store);
         console.log("[ai-filter] configuration loaded", store);
         try {

--- a/options/options.html
+++ b/options/options.html
@@ -6,6 +6,17 @@
 </head>
 <body>
     <label>Endpoint: <input id="endpoint" type="text"></label><br>
+    <label>Prompt template:
+        <select id="template"></select>
+    </label><br>
+    <div id="custom-template-container" style="display:none">
+        <label>Custom template</label><br>
+        <textarea id="custom-template" rows="6" cols="60"></textarea>
+        <p>Placeholders: {{system}}, {{email}}, {{operator}}, {{query}}</p>
+    </div>
+    <label>System instructions:</label><br>
+    <textarea id="system-instructions" rows="4" cols="60"></textarea>
+    <button id="reset-system">Reset to default</button><br>
     <button id="save">Save</button>
     <script src="options.js"></script>
 </body>

--- a/options/options.js
+++ b/options/options.js
@@ -1,14 +1,54 @@
 document.addEventListener('DOMContentLoaded', async () => {
-    let { endpoint = 'http://127.0.0.1:5000/v1/classify' } = await browser.storage.local.get(['endpoint']);
-    document.getElementById('endpoint').value = endpoint;
-});
+    const defaults = await browser.storage.local.get([
+        'endpoint',
+        'templateName',
+        'customTemplate',
+        'customSystemPrompt'
+    ]);
+    document.getElementById('endpoint').value = defaults.endpoint || 'http://127.0.0.1:5000/v1/classify';
 
-document.getElementById('save').addEventListener('click', async () => {
-    const endpoint = document.getElementById('endpoint').value;
-    await browser.storage.local.set({ endpoint });
-    try {
-        await browser.aiFilter.initConfig({ endpoint });
-    } catch (e) {
-        console.error('[ai-filter][options] failed to apply config', e);
+    const templates = {
+        openai: browser.i18n.getMessage('template.openai'),
+        qwen: browser.i18n.getMessage('template.qwen'),
+        mistral: browser.i18n.getMessage('template.mistral'),
+        custom: browser.i18n.getMessage('template.custom')
+    };
+    const templateSelect = document.getElementById('template');
+    for (const [value, label] of Object.entries(templates)) {
+        const opt = document.createElement('option');
+        opt.value = value;
+        opt.textContent = label;
+        templateSelect.appendChild(opt);
     }
+    templateSelect.value = defaults.templateName || 'openai';
+
+    const customBox = document.getElementById('custom-template-container');
+    const customTemplate = document.getElementById('custom-template');
+    customTemplate.value = defaults.customTemplate || '';
+
+    function updateVisibility() {
+        customBox.style.display = templateSelect.value === 'custom' ? 'block' : 'none';
+    }
+    templateSelect.addEventListener('change', updateVisibility);
+    updateVisibility();
+
+    const DEFAULT_SYSTEM = 'Determine whether the email satisfies the user\'s criterion.';
+    const systemBox = document.getElementById('system-instructions');
+    systemBox.value = defaults.customSystemPrompt || DEFAULT_SYSTEM;
+    document.getElementById('reset-system').addEventListener('click', () => {
+        systemBox.value = DEFAULT_SYSTEM;
+    });
+
+    document.getElementById('save').addEventListener('click', async () => {
+        const endpoint = document.getElementById('endpoint').value;
+        const templateName = templateSelect.value;
+        const customTemplateText = customTemplate.value;
+        const customSystemPrompt = systemBox.value;
+        await browser.storage.local.set({ endpoint, templateName, customTemplate: customTemplateText, customSystemPrompt });
+        try {
+            await browser.aiFilter.initConfig({ endpoint, templateName, customTemplate: customTemplateText, customSystemPrompt });
+        } catch (e) {
+            console.error('[ai-filter][options] failed to apply config', e);
+        }
+    });
 });

--- a/prompt_templates/mistral.txt
+++ b/prompt_templates/mistral.txt
@@ -1,0 +1,7 @@
+[INST] {{system}}
+
+Email:
+{{email}}
+
+Criterion ({{operator}}): {{query}}
+[/INST]

--- a/prompt_templates/openai.txt
+++ b/prompt_templates/openai.txt
@@ -1,0 +1,9 @@
+<|im_start|>system
+{{system}}<|im_end|>
+<|im_start|>user
+**Email Contents**
+```
+{{email}}
+```
+Classification Criterion ({{operator}}): {{query}}<|im_end|>
+<|im_start|>assistant

--- a/prompt_templates/qwen.txt
+++ b/prompt_templates/qwen.txt
@@ -1,0 +1,10 @@
+<|im_start|>system
+{{system}}
+<|im_end|>
+<|im_start|>user
+Email:
+{{email}}
+
+Criterion ({{operator}}): {{query}}
+<|im_end|>
+<|im_start|>assistant


### PR DESCRIPTION
## Summary
- allow choosing built-in or custom templates
- add UI controls for prompt format and system instructions
- load templates from plain text files
- compose system prompt from static prefix/suffix and user text

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684fac89d934832f9d0c252bc09448bf