### PR TITLE
Fix XML parse warning when loading templates

### DIFF
--- a/modules/ExpressionSearchFilter.jsm
+++ b/modules/ExpressionSearchFilter.jsm
@@ -123,6 +123,7 @@ function loadTemplate(name) {
     let url = `resource://aifilter/prompt_templates/${name}.txt`;
     let xhr = new XMLHttpRequest();
     xhr.open("GET", url, false);
+    xhr.overrideMimeType("text/plain");
     xhr.send();
     if (xhr.status === 0 || xhr.status === 200) {
       return xhr.responseText;


### PR DESCRIPTION
## Summary
- override MIME type when fetching template files to avoid XML parsing errors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685103d71fb8832fab13e0437f366d44