### PR TITLE
Remove operator argument from prompts

### DIFF
--- a/_locales/en-US/messages.json
+++ b/_locales/en-US/messages.json
@@ -8,7 +8,7 @@
   "options.customTemplate": { "message": "Custom template" },
   "options.systemInstructions": { "message": "System instructions" },
   "options.reset": { "message": "Reset to default" },
-  "options.placeholders": { "message": "Placeholders: {{system}}, {{email}}, {{operator}}, {{query}}" },
+  "options.placeholders": { "message": "Placeholders: {{system}}, {{email}}, {{query}}" },
   "template.openai": { "message": "OpenAI / ChatML" },
   "template.qwen": { "message": "Qwen" },
   "template.mistral": { "message": "Mistral" },

--- a/modules/ExpressionSearchFilter.jsm
+++ b/modules/ExpressionSearchFilter.jsm
@@ -156,12 +156,11 @@ function buildSystemPrompt() {
   return SYSTEM_PREFIX + (gCustomSystemPrompt || DEFAULT_CUSTOM_SYSTEM_PROMPT) + SYSTEM_SUFFIX;
 }
 
-function buildPrompt(body, criterion, opName) {
+function buildPrompt(body, criterion) {
   console.log(`[ai-filter][ExpressionSearchFilter] Building prompt with criterion: "${criterion}"`);
   const data = {
     system: buildSystemPrompt(),
     email: body,
-    operator: opName,
     query: criterion,
   };
   let template = gTemplateText || loadTemplate(gTemplateName);
@@ -189,7 +188,7 @@ class ClassificationTerm extends CustomerTermBase {
 
     let body = getPlainText(msgHdr);
     let payload = JSON.stringify({
-      prompt: buildPrompt(body, value, opName),
+      prompt: buildPrompt(body, value),
       max_tokens: 4096,
       temperature: 0.6,
       top_p: 0.95,

--- a/options/options.html
+++ b/options/options.html
@@ -132,7 +132,7 @@
         <div id="custom-template-container" class="form-group" style="display:none">
             <label>Custom template</label>
             <textarea id="custom-template" rows="6" cols="60" placeholder="Enter your custom template here..."></textarea>
-            <p class="placeholder-text">Placeholders: {{system}}, {{email}}, {{operator}}, {{query}}</p>
+            <p class="placeholder-text">Placeholders: {{system}}, {{email}}, {{query}}</p>
         </div>
 
         <div class="form-group">

--- a/prompt_templates/mistral.txt
+++ b/prompt_templates/mistral.txt
@@ -3,5 +3,6 @@
 Email:
 {{email}}
 
-Criterion ({{operator}}): {{query}}
+Criterion: {{query}}
+Remember to ONLY return the JSON object described in the system instructions.
 [/INST]

--- a/prompt_templates/openai.txt
+++ b/prompt_templates/openai.txt
@@ -5,5 +5,6 @@
 ```
 {{email}}
 ```
-Classification Criterion ({{operator}}): {{query}}<|im_end|>
+Classification Criterion: {{query}}
+Remember to ONLY return the JSON object described in the system instructions.<|im_end|>
 <|im_start|>assistant

--- a/prompt_templates/qwen.txt
+++ b/prompt_templates/qwen.txt
@@ -5,6 +5,7 @@
 Email:
 {{email}}
 
-Criterion ({{operator}}): {{query}}
+Criterion: {{query}}
+Remember to ONLY return the JSON object described in the system instructions.
 <|im_end|>
 <|im_start|>assistant


### PR DESCRIPTION
## Summary
- drop operator placeholder from templates
- update prompt builder to exclude operator
- adjust options page text about placeholders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685225a88a4c832f85af35eaef610ffe