### PR TITLE
Expose AI parameters in options

### DIFF
--- a/background.js
+++ b/background.js
@@ -14,7 +14,7 @@
 console.log("[ai-filter] background.js loaded – ready to classify");
 (async () => {
     try {
-        const store = await browser.storage.local.get(["endpoint", "templateName", "customTemplate", "customSystemPrompt"]);
+        const store = await browser.storage.local.get(["endpoint", "templateName", "customTemplate", "customSystemPrompt", "aiParams"]);
         await browser.aiFilter.initConfig(store);
         console.log("[ai-filter] configuration loaded", store);
         try {

--- a/modules/ExpressionSearchFilter.jsm
+++ b/modules/ExpressionSearchFilter.jsm
@@ -118,6 +118,20 @@ let gCustomTemplate = "";
 let gCustomSystemPrompt = DEFAULT_CUSTOM_SYSTEM_PROMPT;
 let gTemplateText = "";
 
+let gAiParams = {
+  max_tokens: 4096,
+  temperature: 0.6,
+  top_p: 0.95,
+  seed: -1,
+  repetition_penalty: 1.0,
+  top_k: 20,
+  min_p: 0,
+  presence_penalty: 0,
+  frequency_penalty: 0,
+  typical_p: 1,
+  tfs: 1,
+};
+
 function loadTemplate(name) {
   try {
     let url = `resource://aifilter/prompt_templates/${name}.txt`;
@@ -146,6 +160,13 @@ function setConfig(config = {}) {
     }
     if (typeof config.customSystemPrompt === "string") {
         gCustomSystemPrompt = config.customSystemPrompt;
+    }
+    if (config.aiParams && typeof config.aiParams === "object") {
+        for (let [k, v] of Object.entries(config.aiParams)) {
+            if (k in gAiParams && typeof v !== "undefined") {
+                gAiParams[k] = v;
+            }
+        }
     }
     gTemplateText = gTemplateName === "custom" ? gCustomTemplate : loadTemplate(gTemplateName);
     console.log(`[ai-filter][ExpressionSearchFilter] Endpoint set to ${gEndpoint}`);
@@ -187,20 +208,10 @@ class ClassificationTerm extends CustomerTermBase {
     }
 
     let body = getPlainText(msgHdr);
-    let payload = JSON.stringify({
-      prompt: buildPrompt(body, value),
-      max_tokens: 4096,
-      temperature: 0.6,
-      top_p: 0.95,
-      seed: -1,
-      repetition_penalty: 1.0,
-      top_k: 20,
-      min_p: 0,
-      presence_penalty: 0,
-      frequency_penalty: 0,
-      typical_p: 1,
-      tfs: 1
-    });
+    let payloadObj = Object.assign({
+      prompt: buildPrompt(body, value)
+    }, gAiParams);
+    let payload = JSON.stringify(payloadObj);
 
 
     console.log(`[ai-filter][ExpressionSearchFilter] Sending classification request to ${gEndpoint}`);

--- a/options/options.html
+++ b/options/options.html
@@ -142,7 +142,55 @@
 
         <div class="button-group">
             <button id="reset-system">Reset to default</button>
+            <button id="toggle-advanced" type="button">Advanced</button>
             <button id="save">Save</button>
+        </div>
+
+        <div id="advanced-options" style="display:none">
+            <div class="form-group">
+                <label for="max_tokens">Max tokens:</label>
+                <input type="number" id="max_tokens">
+            </div>
+            <div class="form-group">
+                <label for="temperature">Temperature:</label>
+                <input type="number" step="0.01" id="temperature">
+            </div>
+            <div class="form-group">
+                <label for="top_p">Top P:</label>
+                <input type="number" step="0.01" id="top_p">
+            </div>
+            <div class="form-group">
+                <label for="seed">Seed:</label>
+                <input type="number" id="seed">
+            </div>
+            <div class="form-group">
+                <label for="repetition_penalty">Repetition penalty:</label>
+                <input type="number" step="0.01" id="repetition_penalty">
+            </div>
+            <div class="form-group">
+                <label for="top_k">Top K:</label>
+                <input type="number" id="top_k">
+            </div>
+            <div class="form-group">
+                <label for="min_p">Min P:</label>
+                <input type="number" step="0.01" id="min_p">
+            </div>
+            <div class="form-group">
+                <label for="presence_penalty">Presence penalty:</label>
+                <input type="number" step="0.01" id="presence_penalty">
+            </div>
+            <div class="form-group">
+                <label for="frequency_penalty">Frequency penalty:</label>
+                <input type="number" step="0.01" id="frequency_penalty">
+            </div>
+            <div class="form-group">
+                <label for="typical_p">Typical P:</label>
+                <input type="number" step="0.01" id="typical_p">
+            </div>
+            <div class="form-group">
+                <label for="tfs">TFS:</label>
+                <input type="number" step="0.01" id="tfs">
+            </div>
         </div>
     </main>
 


### PR DESCRIPTION
## Summary
- add advanced AI parameter settings in the options UI
- allow background to load/save these parameters
- support new parameters in ExpressionSearchFilter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68535693b6d8832faac1ae5b04090b03