### PR TITLE
Implement colorized logging with debug mode

### DIFF
--- a/_locales/en-US/messages.json
+++ b/_locales/en-US/messages.json
@@ -13,5 +13,6 @@
   "template.qwen": { "message": "Qwen" },
   "template.mistral": { "message": "Mistral" },
   "template.custom": { "message": "Custom" },
-  "options.save": { "message": "Save" }
+  "options.save": { "message": "Save" },
+  "options.debugLogging": { "message": "Enable debug logging" }
 }

--- a/background.js
+++ b/background.js
@@ -10,56 +10,59 @@
 
 "use strict";
 
+let logger;
 // Startup
-console.log("[ai-filter] background.js loaded – ready to classify");
 (async () => {
+    logger = await import(browser.runtime.getURL("logger.js"));
+    logger.aiLog("background.js loaded – ready to classify", {debug: true});
     try {
-        const store = await browser.storage.local.get(["endpoint", "templateName", "customTemplate", "customSystemPrompt", "aiParams"]);
+        const store = await browser.storage.local.get(["endpoint", "templateName", "customTemplate", "customSystemPrompt", "aiParams", "debugLogging"]);
+        logger.setDebug(store.debugLogging);
         await browser.aiFilter.initConfig(store);
-        console.log("[ai-filter] configuration loaded", store);
+        logger.aiLog("configuration loaded", {debug: true}, store);
         try {
             await browser.DomContentScript.registerWindow(
                 "chrome://messenger/content/FilterEditor.xhtml",
                 "resource://aifilter/content/filterEditor.js"
             );
-            console.log("[ai-filter] registered FilterEditor content script");
+            logger.aiLog("registered FilterEditor content script", {debug: true});
         } catch (e) {
-            console.error("[ai-filter] failed to register content script", e);
+            logger.aiLog("failed to register content script", {level: 'error'}, e);
         }
     } catch (err) {
-        console.error("[ai-filter] failed to load config:", err);
+        logger.aiLog("failed to load config", {level: 'error'}, err);
     }
 })();
 
 // Listen for messages from UI/devtools
 browser.runtime.onMessage.addListener((msg) => {
-    console.log("[ai-filter] onMessage received:", msg);
+    logger.aiLog("onMessage received", {debug: true}, msg);
 
     if (msg?.type === "aiFilter:test") {
         const { text = "", criterion = "" } = msg;
-        console.log("[ai-filter] aiFilter:test – text:", text);
-        console.log("[ai-filter] aiFilter:test – criterion:", criterion);
+        logger.aiLog("aiFilter:test – text", {debug: true}, text);
+        logger.aiLog("aiFilter:test – criterion", {debug: true}, criterion);
 
         try {
-            console.log("[ai-filter] Calling browser.aiFilter.classify()");
+            logger.aiLog("Calling browser.aiFilter.classify()", {debug: true});
             const result = browser.aiFilter.classify(text, criterion);
-            console.log("[ai-filter] classify() returned:", result);
+            logger.aiLog("classify() returned", {debug: true}, result);
             return { match: result };
         }
         catch (err) {
-            console.error("[ai-filter] Error in classify():", err);
+            logger.aiLog("Error in classify()", {level: 'error'}, err);
             // rethrow so the caller sees the failure
             throw err;
         }
     }
     else {
-        console.warn("[ai-filter] Unknown message type, ignoring:", msg?.type);
+        logger.aiLog("Unknown message type, ignoring", {level: 'warn'}, msg?.type);
     }
 });
 
 // Catch any unhandled rejections
 window.addEventListener("unhandledrejection", ev => {
-    console.error("[ai-filter] Unhandled promise rejection:", ev.reason);
+    logger.aiLog("Unhandled promise rejection", {level: 'error'}, ev.reason);
 });
 
 browser.runtime.onInstalled.addListener(async ({ reason }) => {

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,24 @@
+let debugEnabled = false;
+export function setDebug(value) {
+    debugEnabled = !!value;
+}
+
+function getCaller() {
+    try {
+        const stack = new Error().stack.split("\n");
+        if (stack.length >= 3) {
+            return stack[2].trim().replace(/^at\s+/, '');
+        }
+    } catch (e) {}
+    return '';
+}
+
+export function aiLog(message, opts = {}, ...args) {
+    const { level = 'log', debug = false } = opts;
+    if (debug && !debugEnabled) {
+        return;
+    }
+    const caller = getCaller();
+    const prefix = caller ? `[ai-filter][${caller}]` : '[ai-filter]';
+    console[level](`%c${prefix}`, 'color:#1c92d2;font-weight:bold', message, ...args);
+}

--- a/modules/logger.jsm
+++ b/modules/logger.jsm
@@ -1,0 +1,26 @@
+var EXPORTED_SYMBOLS = ['aiLog', 'setDebug'];
+let debugEnabled = false;
+
+function setDebug(value) {
+    debugEnabled = !!value;
+}
+
+function getCaller() {
+    try {
+        let stack = new Error().stack.split('\n');
+        if (stack.length >= 3) {
+            return stack[2].trim().replace(/^@?\s*\(?/,'').replace(/^at\s+/, '');
+        }
+    } catch (e) {}
+    return '';
+}
+
+function aiLog(message, opts = {}, ...args) {
+    const { level = 'log', debug = false } = opts;
+    if (debug && !debugEnabled) {
+        return;
+    }
+    const caller = getCaller();
+    const prefix = caller ? `[ai-filter][${caller}]` : '[ai-filter]';
+    console[level](`%c${prefix}`, 'color:#1c92d2;font-weight:bold', message, ...args);
+}

--- a/options/options.html
+++ b/options/options.html
@@ -148,6 +148,11 @@
 
         <div id="advanced-options" style="display:none">
             <div class="form-group">
+                <label>
+                    <input type="checkbox" id="debug-logging"> Enable debug logging
+                </label>
+            </div>
+            <div class="form-group">
                 <label for="max_tokens">Max tokens:</label>
                 <input type="number" id="max_tokens">
             </div>


### PR DESCRIPTION
## Summary
- add custom logger with optional debug mode
- colorize console output and include caller info
- store debug logging preference
- wire debug option into options page and config
- replace console usage with logger
- fix logger import before resource registration

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6856581d44b0832f90c09ffa8a8c4d73