### PR TITLE
Add async classifyText and update event handlers

### DIFF
--- a/background.js
+++ b/background.js
@@ -35,7 +35,7 @@ let logger;
 })();
 
 // Listen for messages from UI/devtools
-browser.runtime.onMessage.addListener((msg) => {
+browser.runtime.onMessage.addListener(async (msg) => {
     logger.aiLog("onMessage received", {debug: true}, msg);
 
     if (msg?.type === "aiFilter:test") {
@@ -45,7 +45,7 @@ browser.runtime.onMessage.addListener((msg) => {
 
         try {
             logger.aiLog("Calling browser.aiFilter.classify()", {debug: true});
-            const result = browser.aiFilter.classify(text, criterion);
+            const result = await browser.aiFilter.classify(text, criterion);
             logger.aiLog("classify() returned", {debug: true}, result);
             return { match: result };
         }

--- a/experiment/api.js
+++ b/experiment/api.js
@@ -70,10 +70,10 @@ var aiFilter = class extends ExtensionCommon.ExtensionAPI {
                         aiLog("[api] failed to apply config", {level: 'error'}, err);
                     }
                 },
-                classify: (text, criterion) => {
+                classify: async (text, criterion) => {
                     aiLog("[api] classify() called", {debug: true}, text, criterion);
                     try {
-                        return AiClassifier.classifyTextSync(text, criterion);
+                        return await AiClassifier.classifyText(text, criterion);
                     }
                     catch (err) {
                         aiLog("[api] error in classify()", {level: 'error'}, err);


### PR DESCRIPTION
## Summary
- implement `classifyText` using `fetch` for asynchronous requests
- expose the async classifier through the experiment API
- update background message handling to await the async API
- refactor classifier helpers so sync and async methods reuse logic

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685af768f8c8832f8233c6b680c81cfb