### PR TITLE
Switch AiClassifier to ES module with storage cache

### DIFF
--- a/background.js
+++ b/background.js
@@ -17,12 +17,8 @@ let AiClassifier;
     logger = await import(browser.runtime.getURL("logger.js"));
     logger.aiLog("background.js loaded – ready to classify", {debug: true});
     try {
-        if (typeof ChromeUtils !== "undefined") {
-            ({ AiClassifier } = ChromeUtils.import("resource://aifilter/modules/AiClassifier.jsm"));
-            logger.aiLog("AiClassifier imported", {debug: true});
-        } else {
-            logger.aiLog("ChromeUtils is undefined, skipping AiClassifier import", {level: 'warn'});
-        }
+        AiClassifier = await import(browser.runtime.getURL('modules/AiClassifier.js'));
+        logger.aiLog("AiClassifier imported", {debug: true});
     } catch (e) {
         logger.aiLog("failed to import AiClassifier", {level: 'error'}, e);
     }

--- a/experiment/api.js
+++ b/experiment/api.js
@@ -36,7 +36,7 @@ var aiFilter = class extends ExtensionCommon.ExtensionAPI {
         setDebug = loggerMod.setDebug;
 
         // Now that the resource URL is registered, import the classifier
-        ({ AiClassifier } = ChromeUtils.import("resource://aifilter/modules/AiClassifier.jsm"));
+        AiClassifier = ChromeUtils.importESModule("resource://aifilter/modules/AiClassifier.js");
         aiLog("[api] onStartup()", {debug: true});
 
 

--- a/modules/ExpressionSearchFilter.jsm
+++ b/modules/ExpressionSearchFilter.jsm
@@ -3,7 +3,7 @@ var { ExtensionParent } = ChromeUtils.importESModule("resource://gre/modules/Ext
 var { MailServices }    = ChromeUtils.importESModule("resource:///modules/MailServices.sys.mjs");
 var { Services }        = globalThis || ChromeUtils.importESModule("resource://gre/modules/Services.sys.mjs");
 var { aiLog } = ChromeUtils.import("resource://aifilter/modules/logger.jsm");
-var { AiClassifier }    = ChromeUtils.import("resource://aifilter/modules/AiClassifier.jsm");
+var AiClassifier    = ChromeUtils.importESModule("resource://aifilter/modules/AiClassifier.js");
 var { getPlainText }    = ChromeUtils.import("resource://aifilter/modules/messageUtils.jsm");
 
 function sha256Hex(str) {

--- a/options/options.js
+++ b/options/options.js
@@ -1,5 +1,6 @@
 document.addEventListener('DOMContentLoaded', async () => {
     const logger = await import(browser.runtime.getURL('logger.js'));
+    const AiClassifier = await import(browser.runtime.getURL('modules/AiClassifier.js'));
     const defaults = await browser.storage.local.get([
         'endpoint',
         'templateName',
@@ -88,6 +89,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         await browser.storage.local.set({ endpoint, templateName, customTemplate: customTemplateText, customSystemPrompt, aiParams: aiParamsSave, debugLogging });
         try {
             await browser.aiFilter.initConfig({ endpoint, templateName, customTemplate: customTemplateText, customSystemPrompt, aiParams: aiParamsSave, debugLogging });
+            AiClassifier.setConfig({ endpoint, templateName, customTemplate: customTemplateText, customSystemPrompt, aiParams: aiParamsSave, debugLogging });
             logger.setDebug(debugLogging);
         } catch (e) {
             logger.aiLog('[options] failed to apply config', {level: 'error'}, e);


### PR DESCRIPTION
## Summary
- convert AiClassifier.jsm to a standard ES module
- use `browser.storage.local` for cache persistence
- fetch prompt templates via `fetch`
- load AiClassifier dynamically in background and options scripts
- update privileged modules to import the new ES module

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b831d7088832fb2f122a931fe7d5a