### PR TITLE
Implement automatic classification rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ message meets a specified criterion.
 - **Persistent result caching** – classification results are saved to disk so messages aren't re-evaluated across restarts.
 - **Advanced parameters** – tune generation settings like temperature, top‑p and more from the options page.
 - **Debug logging** – optional colorized logs help troubleshoot interactions with the AI service.
+- **Automatic rules** – create rules that tag or move new messages based on AI classification.
 - **Packaging script** – `build-xpi.ps1` builds an XPI ready for installation.
 
 ## Architecture Overview
@@ -45,7 +46,7 @@ APIs:
 | `modules/ExpressionSearchFilter.jsm`    | Custom filter term and AI request logic.       |
 | `experiment/api.js`                     | Bridges WebExtension code with privileged APIs.|
 | `content/filterEditor.js`               | Patches the filter editor interface.           |
-| `options/options.html` and `options.js` | Endpoint configuration UI.                     |
+| `options/options.html` and `options.js` | Endpoint and rule configuration UI. |
 | `logger.js` and `modules/logger.jsm`    | Colorized logging with optional debug mode.    |
 
 ## Building

--- a/options/options.html
+++ b/options/options.html
@@ -78,6 +78,21 @@
             flex-wrap: wrap;
         }
 
+        #rules-container {
+            margin-top: 10px;
+        }
+
+        .rule {
+            border: 1px solid #ccc;
+            padding: 10px;
+            margin-bottom: 10px;
+            border-radius: 4px;
+        }
+
+        .rule-actions {
+            margin-top: 10px;
+        }
+
         button {
             padding: 10px 20px;
             border: none;
@@ -197,6 +212,11 @@
                 <input type="number" step="0.01" id="tfs">
             </div>
         </div>
+
+        <hr>
+        <h2>Classification Rules</h2>
+        <div id="rules-container"></div>
+        <button id="add-rule" type="button">Add Rule</button>
     </main>
 
     <script src="options.js"></script>


### PR DESCRIPTION
## Summary
- add a section to manage classification rules in the options page
- persist rules to `aiRules` in `browser.storage.local`
- process rules when new mail arrives and apply tags or moves
- document the new feature in the README

## Testing
- `find . -name '*test*'`

------
https://chatgpt.com/codex/tasks/task_e_685b8b80cb70832f82a1c02de44f4ede