### PR TITLE
Fix logger initialization and remove Services dependency

### DIFF
--- a/options/options.js
+++ b/options/options.js
@@ -147,7 +147,7 @@ document.addEventListener('DOMContentLoaded', async () => {
         })).filter(r => r.criterion);
         await browser.storage.local.set({ endpoint, templateName, customTemplate: customTemplateText, customSystemPrompt, aiParams: aiParamsSave, debugLogging, aiRules: rules });
         try {
-            AiClassifier.setConfig({ endpoint, templateName, customTemplate: customTemplateText, customSystemPrompt, aiParams: aiParamsSave, debugLogging });
+            await AiClassifier.setConfig({ endpoint, templateName, customTemplate: customTemplateText, customSystemPrompt, aiParams: aiParamsSave, debugLogging });
             logger.setDebug(debugLogging);
         } catch (e) {
             logger.aiLog('[options] failed to apply config', {level: 'error'}, e);


### PR DESCRIPTION
## Summary
- initialize background script once logger is loaded
- await template configuration when background/options load
- detect Services module only in privileged contexts
- prevent synchronous functions from running when Services isn't available

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b9b6d8e30832fa35cb3530a14e18d