### PR TITLE
Add context menu helper to apply AI rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ message meets a specified criterion.
 - **Advanced parameters** – tune generation settings like temperature, top‑p and more from the options page.
 - **Debug logging** – optional colorized logs help troubleshoot interactions with the AI service.
 - **Automatic rules** – create rules that tag or move new messages based on AI classification.
+- **Context menu** – apply AI rules to selected messages from the message list or display.
 - **Packaging script** – `build-xpi.ps1` builds an XPI ready for installation.
 
 ## Architecture Overview
@@ -100,6 +101,7 @@ Sortana requests the following Thunderbird permissions:
 - `messagesUpdate` – change message properties such as tags and junk status.
 - `messagesTagsList` – retrieve existing message tags for rule actions.
 - `accountsRead` – list accounts and folders for move actions.
+- `menus` – add context menu commands.
 
 ## License
 

--- a/manifest.json
+++ b/manifest.json
@@ -29,6 +29,7 @@
     "messagesMove",
     "messagesUpdate",
     "messagesTagsList",
-    "accountsRead"
+    "accountsRead",
+    "menus"
   ]
 }


### PR DESCRIPTION
## Summary
- add `applyAiRules` helper to reuse AI rule logic
- expose "Apply AI Rules" options in message list and display context menus
- process selected messages in the menu handler
- add `menus` permission
- document the new context menu feature

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_685c3ff6b44c832faee0784f1c354875