### PR TITLE
Fix message display context for menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ message meets a specified criterion.
 - **Advanced parameters** – tune generation settings like temperature, top‑p and more from the options page.
 - **Debug logging** – optional colorized logs help troubleshoot interactions with the AI service.
 - **Automatic rules** – create rules that tag or move new messages based on AI classification.
-- **Context menu** – apply AI rules to selected messages from the message list or display.
+- **Context menu** – apply AI rules from the message list or the message display action button.
 - **Status icons** – toolbar icons indicate when messages are queued or being classified.
 - **Packaging script** – `build-xpi.ps1` builds an XPI ready for installation.
 

--- a/background.js
+++ b/background.js
@@ -126,8 +126,20 @@ async function applyAiRules(idsInput) {
     browser.menus.create({
         id: "apply-ai-rules-display",
         title: "Apply AI Rules",
-        contexts: ["message_display"],
+        contexts: ["message_display_action"],
     });
+
+    if (browser.messageDisplayAction) {
+        browser.messageDisplayAction.onClicked.addListener(async (tab) => {
+            try {
+                const msgs = await browser.messageDisplay.getDisplayedMessages(tab.id);
+                const ids = msgs.map(m => m.id);
+                await applyAiRules(ids);
+            } catch (e) {
+                logger.aiLog("failed to apply AI rules from action", { level: 'error' }, e);
+            }
+        });
+    }
 
     browser.menus.onClicked.addListener(async info => {
         if (info.menuItemId === "apply-ai-rules-list" || info.menuItemId === "apply-ai-rules-display") {


### PR DESCRIPTION
## Summary
- update README to mention the message display action button
- use `message_display_action` context for the apply rules menu
- handle clicks on the message display action button to run AI rules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c553270cc832fbeb809e02ec43ffd