### PR TITLE
Fix async rule loop

### DIFF
--- a/background.js
+++ b/background.js
@@ -106,8 +106,10 @@ async function applyAiRules(idsInput) {
             try {
                 const full = await messenger.messages.getFull(id);
                 const text = buildEmailText(full);
-                const cacheKey = await sha256Hex(`${id}|${rule.criterion}`);
-                const matched = await AiClassifier.classifyText(text, rule.criterion, cacheKey);
+
+                for (const rule of aiRules) {
+                    const cacheKey = await sha256Hex(`${id}|${rule.criterion}`);
+                    const matched = await AiClassifier.classifyText(text, rule.criterion, cacheKey);
                     if (matched) {
                         for (const act of (rule.actions || [])) {
                             if (act.type === 'tag' && act.tagKey) {


### PR DESCRIPTION
## Summary
- iterate through rules inside queued message processing

## Testing
- `node -e "require('./background.js')"` *(fails: browser undefined, but no syntax errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dc5aad6dc832f8d62ce172e371f24