### PR TITLE
Add cache clearing controls

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,9 @@
     "default_icon": "resources/img/logo32.png"
   },
   "message_display_action": {
-    "default_icon": "resources/img/logo32.png"
+    "default_icon": "resources/img/logo32.png",
+    "default_title": "Classify",
+    "default_label": "Classify"
   },
   "background": { "scripts": [ "background.js" ] },
   "options_ui": {

--- a/modules/AiClassifier.js
+++ b/modules/AiClassifier.js
@@ -210,6 +210,25 @@ function cacheResult(cacheKey, matched) {
   }
 }
 
+async function removeCacheEntries(keys = []) {
+  if (!Array.isArray(keys)) {
+    keys = [keys];
+  }
+  if (!gCacheLoaded) {
+    await loadCache();
+  }
+  let removed = false;
+  for (let key of keys) {
+    if (gCache.delete(key)) {
+      removed = true;
+      aiLog(`[AiClassifier] Removed cache entry '${key}'`, {debug: true});
+    }
+  }
+  if (removed) {
+    await saveCache();
+  }
+}
+
 function classifyTextSync(text, criterion, cacheKey = null) {
   if (!Services?.tm?.spinEventLoopUntil) {
     throw new Error("classifyTextSync requires Services");
@@ -288,4 +307,4 @@ async function classifyText(text, criterion, cacheKey = null) {
   }
 }
 
-export { classifyText, classifyTextSync, setConfig };
+export { classifyText, classifyTextSync, setConfig, removeCacheEntries };

--- a/resources/clearCacheButton.js
+++ b/resources/clearCacheButton.js
@@ -1,0 +1,22 @@
+(function() {
+  function addButton() {
+    const toolbar = document.querySelector("#header-view-toolbar") ||
+                    document.querySelector("#mail-toolbox toolbar");
+    if (!toolbar || document.getElementById('sortana-clear-cache-button')) return;
+    const button = document.createXULElement ?
+          document.createXULElement('toolbarbutton') :
+          document.createElement('button');
+    button.id = 'sortana-clear-cache-button';
+    button.setAttribute('label', 'Clear Cache');
+    button.className = 'toolbarbutton-1';
+    button.addEventListener('command', () => {
+      browser.runtime.sendMessage({ type: 'sortana:clearCacheForDisplayed' });
+    });
+    toolbar.appendChild(button);
+  }
+  if (document.readyState === 'complete' || document.readyState === 'interactive') {
+    addButton();
+  } else {
+    document.addEventListener('DOMContentLoaded', addButton, { once: true });
+  }
+})();


### PR DESCRIPTION
## Summary
- allow removing classification results from the cache
- expose new `removeCacheEntries` helper
- register a message display script with a `Clear Cache` button
- add context menu commands to clear cached results
- label the Sortana action button "Classify"

## Testing
- `pre-commit` *(fails: no command found)*

------
https://chatgpt.com/codex/tasks/task_e_685e2f248e48832fb21dc51b95380935