### PR TITLE
Add View Reasoning UI

### DIFF
--- a/resources/reasonButton.js
+++ b/resources/reasonButton.js
@@ -7,7 +7,7 @@
           document.createXULElement('toolbarbutton') :
           document.createElement('button');
     button.id = 'sortana-reason-button';
-    button.setAttribute('label', 'Show Reasoning');
+    button.setAttribute('label', 'View Reasoning');
     button.className = 'toolbarbutton-1';
     const icon = browser.runtime.getURL('resources/img/brain.png');
     if (button.setAttribute) {


### PR DESCRIPTION
## Summary
- support both old and new messageDisplayScripts registration APIs
- add 'View Reasoning' menu items with brain icon
- show 'View Reasoning' button in message header

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e42cf6c88832fb0f7edf84fba8efd