### PR TITLE
Fix message pane buttons

### DIFF
--- a/background.js
+++ b/background.js
@@ -228,11 +228,27 @@ async function clearCacheForMessages(idsInput) {
             browser.messageDisplayAction.setLabel({ label: "Classify" });
         }
     }
-    if (browser.messageDisplayScripts) {
+    if (browser.scripting && browser.scripting.messageDisplay) {
+        try {
+            const scripts = [
+                {
+                    id: "clear-cache-button",
+                    js: [browser.runtime.getURL("resources/clearCacheButton.js")],
+                },
+                {
+                    id: "reason-button",
+                    js: [browser.runtime.getURL("resources/reasonButton.js")],
+                },
+            ];
+            await browser.scripting.messageDisplay.registerScripts(scripts);
+        } catch (e) {
+            logger.aiLog("failed to register message display script", { level: 'warn' }, e);
+        }
+    } else if (browser.messageDisplayScripts) {
         try {
             const scripts = [
                 { js: [browser.runtime.getURL("resources/clearCacheButton.js")] },
-                { js: [browser.runtime.getURL("resources/reasonButton.js")] }
+                { js: [browser.runtime.getURL("resources/reasonButton.js")] },
             ];
             if (browser.messageDisplayScripts.registerScripts) {
                 await browser.messageDisplayScripts.registerScripts(scripts);


### PR DESCRIPTION
## Summary
- update background.js to use `scripting.messageDisplay` API for message pane buttons
- keep fallback to the old `messageDisplayScripts` API

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685e4b832b6c832f810474da1e29f1d5