### PR TITLE
Fix missing getCachedResult export

### DIFF
--- a/modules/AiClassifier.js
+++ b/modules/AiClassifier.js
@@ -387,4 +387,4 @@ async function classifyText(text, criterion, cacheKey = null) {
   }
 }
 
-export { classifyText, classifyTextSync, setConfig, removeCacheEntries, getReason };
+export { classifyText, classifyTextSync, setConfig, removeCacheEntries, getReason, getCachedResult };


### PR DESCRIPTION
## Summary
- export `getCachedResult` from `AiClassifier`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f5efe0d78832f935ecdf5e407d4b7