### PR TITLE
Unify AI caches and add cache key helper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,3 +59,10 @@ base64 data should be replaced with placeholders showing the byte size. The
 final string should have the headers, a brief attachment section, then the plain
 text extracted from all text parts.
 
+### Cache Strategy
+
+`aiCache` persists classification results. Each key is the SHA‑256 hex of
+`"<message id>|<criterion>"` and maps to an object with `matched` and `reason`
+properties. Any legacy `aiReasonCache` data is merged into `aiCache` the first
+time the add-on loads after an update.
+

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ message meets a specified criterion.
 - **Custom system prompts** – tailor the instructions sent to the model for more precise results.
 - **Filter editor integration** – patches Thunderbird's filter editor to accept
   text criteria for AI classification.
-- **Persistent result caching** – classification results are saved to disk so messages aren't re-evaluated across restarts.
+- **Persistent result caching** – classification results and reasoning are saved to disk so messages aren't re-evaluated across restarts.
 - **Advanced parameters** – tune generation settings like temperature, top‑p and more from the options page.
 - **Debug logging** – optional colorized logs help troubleshoot interactions with the AI service.
 - **Automatic rules** – create rules that tag or move new messages based on AI classification.
@@ -24,6 +24,13 @@ message meets a specified criterion.
 - **Context menu** – apply AI rules from the message list or the message display action button.
 - **Status icons** – toolbar icons show when classification is in progress and briefly display success or error states.
 - **Packaging script** – `build-xpi.ps1` builds an XPI ready for installation.
+
+### Cache Storage
+
+Classification results are stored under the `aiCache` key in extension storage.
+Each entry maps a SHA‑256 hash of `"<message id>|<criterion>"` to an object
+containing `matched` and `reason` fields. Older installations with a separate
+`aiReasonCache` will be migrated automatically on startup.
 
 ## Architecture Overview
 

--- a/modules/ExpressionSearchFilter.jsm
+++ b/modules/ExpressionSearchFilter.jsm
@@ -5,15 +5,6 @@ var { aiLog } = ChromeUtils.import("resource://aifilter/modules/logger.jsm");
 var AiClassifier    = ChromeUtils.importESModule("resource://aifilter/modules/AiClassifier.js");
 var { getPlainText }    = ChromeUtils.import("resource://aifilter/modules/messageUtils.jsm");
 
-function sha256Hex(str) {
-  const hasher = Cc["@mozilla.org/security/hash;1"].createInstance(Ci.nsICryptoHash);
-  hasher.init(Ci.nsICryptoHash.SHA256);
-  const data = new TextEncoder().encode(str);
-  hasher.update(data, data.length);
-  const binary = hasher.finish(false);
-  return Array.from(binary, c => ("0" + c.charCodeAt(0).toString(16)).slice(-2)).join("");
-}
-
 var EXPORTED_SYMBOLS = ["AIFilter", "ClassificationTerm"];
 
 class CustomerTermBase {
@@ -70,7 +61,7 @@ class ClassificationTerm extends CustomerTermBase {
                    op === Ci.nsMsgSearchOp.DoesntMatch ? "doesn't match" : `unknown (${op})`;
     aiLog(`[ExpressionSearchFilter] Matching message ${msgHdr.messageId} using op "${opName}" and value "${value}"`, {debug: true});
 
-    let key = [msgHdr.messageId, op, value].map(sha256Hex).join("|");
+    let key = AiClassifier.buildCacheKeySync(msgHdr.messageId, value);
     let body = getPlainText(msgHdr);
 
     let matched = AiClassifier.classifyTextSync(body, value, key);


### PR DESCRIPTION
## Summary
- create `buildCacheKey` helper in `AiClassifier`
- generate SHA‑256 keys with helper everywhere
- store `{matched, reason}` objects in `aiCache`
- migrate old `aiReasonCache` data on startup
- document caching in README and AGENTS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686052e0bd34832f9244bf80fd6c2fb2