### PR TITLE
Use Message-ID for cache keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ text extracted from all text parts.
 ### Cache Strategy
 
 `aiCache` persists classification results. Each key is the SHA‑256 hex of
-`"<message id>|<criterion>"` and maps to an object with `matched` and `reason`
+`"<message Message-ID>|<criterion>"` and maps to an object with `matched` and `reason`
 properties. Any legacy `aiReasonCache` data is merged into `aiCache` the first
 time the add-on loads after an update.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ message meets a specified criterion.
 ### Cache Storage
 
 Classification results are stored under the `aiCache` key in extension storage.
-Each entry maps a SHA‑256 hash of `"<message id>|<criterion>"` to an object
+Each entry maps a SHA‑256 hash of `"<message Message-ID>|<criterion>"` to an object
 containing `matched` and `reason` fields. Older installations with a separate
 `aiReasonCache` will be migrated automatically on startup.
 

--- a/modules/AiClassifier.js
+++ b/modules/AiClassifier.js
@@ -76,11 +76,26 @@ function buildCacheKeySync(id, criterion) {
   return sha256HexSync(`${id}|${criterion}`);
 }
 
-async function buildCacheKey(id, criterion) {
-  if (Services) {
-    return buildCacheKeySync(id, criterion);
+async function resolveHeaderId(id) {
+  if (typeof id === "number" && typeof messenger?.messages?.get === "function") {
+    try {
+      const hdr = await messenger.messages.get(id);
+      if (hdr?.headerMessageId) {
+        return hdr.headerMessageId;
+      }
+    } catch (e) {
+      aiLog(`Failed to resolve headerMessageId for ${id}`, { level: 'warn' }, e);
+    }
   }
-  return sha256Hex(`${id}|${criterion}`);
+  return String(id);
+}
+
+async function buildCacheKey(id, criterion) {
+  const resolvedId = await resolveHeaderId(id);
+  if (Services) {
+    return buildCacheKeySync(resolvedId, criterion);
+  }
+  return sha256Hex(`${resolvedId}|${criterion}`);
 }
 
 async function loadCache() {


### PR DESCRIPTION
## Summary
- resolve numeric Thunderbird IDs to their Message-ID headers
- clarify cache key usage in documentation

## Testing
- `ls test || true`

------
https://chatgpt.com/codex/tasks/task_e_6860e540fc00832f9bca3bdb57fa31eb