### PR TITLE
Add maintenance tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ message meets a specified criterion.
 - **Context menu** – apply AI rules from the message list or the message display action button.
 - **Status icons** – toolbar icons show when classification is in progress and briefly display success or error states.
 - **Packaging script** – `build-xpi.ps1` builds an XPI ready for installation.
+- **Maintenance tab** – view rule counts, cache entries and clear cached results from the options page.
 
 ### Cache Storage
 

--- a/modules/AiClassifier.js
+++ b/modules/AiClassifier.js
@@ -312,6 +312,17 @@ async function removeCacheEntries(keys = []) {
   }
 }
 
+async function clearCache() {
+  if (!gCacheLoaded) {
+    await loadCache();
+  }
+  if (gCache.size > 0) {
+    gCache.clear();
+    await saveCache();
+    aiLog(`[AiClassifier] Cleared cache`, {debug: true});
+  }
+}
+
 function classifyTextSync(text, criterion, cacheKey = null) {
   if (!Services?.tm?.spinEventLoopUntil) {
     throw new Error("classifyTextSync requires Services");
@@ -396,4 +407,4 @@ async function init() {
   await loadCache();
 }
 
-export { classifyText, classifyTextSync, setConfig, removeCacheEntries, getReason, getCachedResult, buildCacheKey, buildCacheKeySync, init };
+export { classifyText, classifyTextSync, setConfig, removeCacheEntries, clearCache, getReason, getCachedResult, buildCacheKey, buildCacheKeySync, init };

--- a/options/options.html
+++ b/options/options.html
@@ -46,6 +46,7 @@
                         <ul>
                             <li class="is-active" data-tab="settings"><a>Settings</a></li>
                             <li data-tab="rules"><a>Rules</a></li>
+                            <li data-tab="maintenance"><a>Maintenance</a></li>
                         </ul>
                     </div>
                 </div>
@@ -170,6 +171,17 @@
                 <h2 class="title is-4">Classification Rules</h2>
                 <div id="rules-container"></div>
                 <button class="button is-link" id="add-rule" type="button">Add Rule</button>
+            </div>
+
+            <div id="maintenance-tab" class="tab-content is-hidden">
+                <h2 class="title is-4">Maintenance</h2>
+                <table class="table is-fullwidth">
+                    <tbody>
+                        <tr><th>Rule count</th><td id="rule-count"></td></tr>
+                        <tr><th>Cache entries</th><td id="cache-count"></td></tr>
+                    </tbody>
+                </table>
+                <button class="button is-danger" id="clear-cache" type="button">Clear Cache</button>
             </div>
         </div>
     </section>

--- a/options/options.js
+++ b/options/options.js
@@ -9,7 +9,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         'customSystemPrompt',
         'aiParams',
         'debugLogging',
-        'aiRules'
+        'aiRules',
+        'aiCache'
     ]);
     const tabButtons = document.querySelectorAll('#main-tabs li');
     const tabs = document.querySelectorAll('.tab-content');
@@ -300,6 +301,15 @@ document.addEventListener('DOMContentLoaded', async () => {
         if (r.stopProcessing) rule.stopProcessing = true;
         return rule;
     }));
+
+    const ruleCountEl = document.getElementById('rule-count');
+    const cacheCountEl = document.getElementById('cache-count');
+    ruleCountEl.textContent = (defaults.aiRules || []).length;
+    cacheCountEl.textContent = defaults.aiCache ? Object.keys(defaults.aiCache).length : 0;
+    document.getElementById('clear-cache').addEventListener('click', async () => {
+        await AiClassifier.clearCache();
+        cacheCountEl.textContent = '0';
+    });
     initialized = true;
 
     document.getElementById('save').addEventListener('click', async () => {


### PR DESCRIPTION
## Summary
- add clearCache to AiClassifier module
- show a new Maintenance tab in the options page
- display rule and cache counts, and allow clearing the cache
- document the new Maintenance tab in README

## Testing
- `node -c options/options.js`
- `node -c modules/AiClassifier.js`


------
https://chatgpt.com/codex/tasks/task_e_6860ee68fc34832f9269f021495967ac