### PR TITLE
Add queue count stat to options page

### DIFF
--- a/background.js
+++ b/background.js
@@ -388,6 +388,8 @@ async function clearCacheForMessages(idsInput) {
             logger.aiLog("failed to clear cache for message", { level: 'error' }, e);
             return { ok: false };
         }
+    } else if (msg?.type === "sortana:getQueueCount") {
+        return { count: queuedCount + (processing ? 1 : 0) };
     } else {
         logger.aiLog("Unknown message type, ignoring", {level: 'warn'}, msg?.type);
     }

--- a/options/options.html
+++ b/options/options.html
@@ -179,6 +179,7 @@
                     <tbody>
                         <tr><th>Rule count</th><td id="rule-count"></td></tr>
                         <tr><th>Cache entries</th><td id="cache-count"></td></tr>
+                        <tr><th>Queue items</th><td id="queue-count"></td></tr>
                     </tbody>
                 </table>
                 <button class="button is-danger" id="clear-cache" type="button">Clear Cache</button>

--- a/options/options.js
+++ b/options/options.js
@@ -304,8 +304,22 @@ document.addEventListener('DOMContentLoaded', async () => {
 
     const ruleCountEl = document.getElementById('rule-count');
     const cacheCountEl = document.getElementById('cache-count');
+    const queueCountEl = document.getElementById('queue-count');
     ruleCountEl.textContent = (defaults.aiRules || []).length;
     cacheCountEl.textContent = defaults.aiCache ? Object.keys(defaults.aiCache).length : 0;
+
+    async function refreshQueueCount() {
+        try {
+            const { count } = await browser.runtime.sendMessage({ type: 'sortana:getQueueCount' });
+            queueCountEl.textContent = count;
+        } catch (e) {
+            queueCountEl.textContent = '?';
+        }
+    }
+
+    refreshQueueCount();
+    setInterval(refreshQueueCount, 2000);
+
     document.getElementById('clear-cache').addEventListener('click', async () => {
         await AiClassifier.clearCache();
         cacheCountEl.textContent = '0';


### PR DESCRIPTION
## Summary
- show the processing queue length on the options maintenance tab
- regularly poll the background script for queue size
- expose queue count via runtime messaging

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6860f58d84ec832f994e949f302f8505