### PR TITLE
Add run time stats in options

### DIFF
--- a/modules/AiClassifier.js
+++ b/modules/AiClassifier.js
@@ -323,6 +323,13 @@ async function clearCache() {
   }
 }
 
+async function getCacheSize() {
+  if (!gCacheLoaded) {
+    await loadCache();
+  }
+  return gCache.size;
+}
+
 function classifyTextSync(text, criterion, cacheKey = null) {
   if (!Services?.tm?.spinEventLoopUntil) {
     throw new Error("classifyTextSync requires Services");
@@ -407,4 +414,4 @@ async function init() {
   await loadCache();
 }
 
-export { classifyText, classifyTextSync, setConfig, removeCacheEntries, clearCache, getReason, getCachedResult, buildCacheKey, buildCacheKeySync, init };
+export { classifyText, classifyTextSync, setConfig, removeCacheEntries, clearCache, getReason, getCachedResult, buildCacheKey, buildCacheKeySync, getCacheSize, init };

--- a/options/options.html
+++ b/options/options.html
@@ -180,6 +180,9 @@
                         <tr><th>Rule count</th><td id="rule-count"></td></tr>
                         <tr><th>Cache entries</th><td id="cache-count"></td></tr>
                         <tr><th>Queue items</th><td id="queue-count"></td></tr>
+                        <tr><th>Current run time</th><td id="current-time">--:--</td></tr>
+                        <tr><th>Average run time</th><td id="average-time">--:--</td></tr>
+                        <tr><th>Total run time</th><td id="total-time">--:--</td></tr>
                     </tbody>
                 </table>
                 <button class="button is-danger" id="clear-cache" type="button">Clear Cache</button>


### PR DESCRIPTION
## Summary
- show current, average, and total classification times
- color-code current time based on deviation from average
- persist timing data and expose via background page
- refresh maintenance data every two seconds

## Testing
- `node --check modules/AiClassifier.js`
- `node --check background.js`
- `node --check options/options.js`


------
https://chatgpt.com/codex/tasks/task_e_6861e1d92d08832f931e3d66eb7a6601