### PR TITLE
Improve maintenance timing display

### DIFF
--- a/options/options.html
+++ b/options/options.html
@@ -180,9 +180,10 @@
                         <tr><th>Rule count</th><td id="rule-count"></td></tr>
                         <tr><th>Cache entries</th><td id="cache-count"></td></tr>
                         <tr><th>Queue items</th><td id="queue-count"></td></tr>
-                        <tr><th>Current run time</th><td id="current-time">--:--</td></tr>
-                        <tr><th>Average run time</th><td id="average-time">--:--</td></tr>
-                        <tr><th>Total run time</th><td id="total-time">--:--</td></tr>
+                        <tr><th>Current run time</th><td id="current-time">--:--:--</td></tr>
+                        <tr><th>Last run time</th><td id="last-time">--:--:--</td></tr>
+                        <tr><th>Average run time</th><td id="average-time">--:--:--</td></tr>
+                        <tr><th>Total run time</th><td id="total-time">--:--:--</td></tr>
                     </tbody>
                 </table>
                 <button class="button is-danger" id="clear-cache" type="button">Clear Cache</button>


### PR DESCRIPTION
## Summary
- show last maintenance run time in options
- format times as clock values
- persist last run time in classify stats
- update refresh interval to 1s

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861f30d1dec832f90ab4cc4bf5e95df