### PR TITLE
Fix reasoning popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Sortana requests the following Thunderbird permissions:
 - `messagesTagsList` – retrieve existing message tags for rule actions.
 - `accountsRead` – list accounts and folders for move actions.
 - `menus` – add context menu commands.
+- `tabs` – open new tabs and query the active tab.
 
 ## Thunderbird Add-on Store Disclosures
 

--- a/details.js
+++ b/details.js
@@ -8,6 +8,12 @@ document.addEventListener('DOMContentLoaded', async () => {
       const tabId = tabs[0]?.id;
       const msgs = tabId ? await browser.messageDisplay.getDisplayedMessages(tabId) : [];
       id = msgs[0]?.id;
+      if (!id) {
+        const mailTabs = await browser.mailTabs.query({ active: true, currentWindow: true });
+        const mailTabId = mailTabs[0]?.id;
+        const selected = mailTabId !== undefined ? await browser.mailTabs.getSelectedMessages(mailTabId) : null;
+        id = selected?.messages?.[0]?.id;
+      }
     } catch (e) {
       console.error('failed to determine message id', e);
     }

--- a/manifest.json
+++ b/manifest.json
@@ -40,6 +40,7 @@
     "messagesTagsList",
     "accountsRead",
     "menus",
-    "scripting"
+    "scripting",
+    "tabs"
   ]
 }


### PR DESCRIPTION
## Summary
- request tabs permission to query active tabs and open detail pages
- document new permission
- handle preview pane when loading details

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868ee0494c4832fa62b1e88bc7d596b