### PR TITLE
Add logging to details page

### DIFF
--- a/details.js
+++ b/details.js
@@ -1,6 +1,13 @@
 document.addEventListener('DOMContentLoaded', async () => {
+  const storage = (globalThis.messenger ?? browser).storage;
+  const logger = await import(browser.runtime.getURL('logger.js'));
+  const { debugLogging } = await storage.local.get('debugLogging');
+  logger.setDebug(debugLogging === true);
+  logger.aiLog('details page loaded', { debug: true });
+
   const params = new URLSearchParams(location.search);
   let id = parseInt(params.get('mid'), 10);
+  logger.aiLog('initial message id', { debug: true }, id);
 
   if (!id) {
     try {
@@ -8,22 +15,27 @@ document.addEventListener('DOMContentLoaded', async () => {
       const tabId = tabs[0]?.id;
       const msgs = tabId ? await browser.messageDisplay.getDisplayedMessages(tabId) : [];
       id = msgs[0]?.id;
+      logger.aiLog('message id from displayed messages', { debug: true }, id);
       if (!id) {
         const mailTabs = await browser.mailTabs.query({ active: true, currentWindow: true });
         const mailTabId = mailTabs[0]?.id;
         const selected = mailTabId !== undefined ? await browser.mailTabs.getSelectedMessages(mailTabId) : null;
         id = selected?.messages?.[0]?.id;
+        logger.aiLog('message id from selected messages', { debug: true }, id);
       }
     } catch (e) {
-      console.error('failed to determine message id', e);
+      logger.aiLog('failed to determine message id', { level: 'error' }, e);
     }
   }
   if (!id) return;
   try {
+    logger.aiLog('requesting message details', {}, id);
     const { subject, results } = await browser.runtime.sendMessage({ type: 'sortana:getDetails', id });
+    logger.aiLog('received details', { debug: true }, { subject, results });
     document.getElementById('subject').textContent = subject;
     const container = document.getElementById('rules');
     for (const r of results) {
+      logger.aiLog('rendering rule result', { debug: true }, r);
       const article = document.createElement('article');
       const color = r.matched === true ? 'is-success' : 'is-danger';
       article.className = `message ${color} mb-4`;
@@ -43,10 +55,11 @@ document.addEventListener('DOMContentLoaded', async () => {
       container.appendChild(article);
     }
     document.getElementById('clear').addEventListener('click', async () => {
+      logger.aiLog('clearing cache for message', {}, id);
       await browser.runtime.sendMessage({ type: 'sortana:clearCacheForMessage', id });
       window.close();
     });
   } catch (e) {
-    console.error('failed to load details', e);
+    logger.aiLog('failed to load details', { level: 'error' }, e);
   }
 });


### PR DESCRIPTION
## Summary
- add logger import and enable debug in `details.js`
- log message id gathering and details retrieval
- log cache clearing action

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868f4990d98832f9698d1c3c0f8b701