### PR TITLE
Fix message id detection for details popup

### DIFF
--- a/background.js
+++ b/background.js
@@ -413,7 +413,7 @@ async function clearCacheForMessages(idsInput) {
         }
     } else if (msg?.type === "sortana:clearCacheForDisplayed") {
         try {
-            const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+            const tabs = await browser.tabs.query({ active: true, lastFocusedWindow: true });
             const tabId = tabs[0]?.id;
             const msgs = tabId ? await browser.messageDisplay.getDisplayedMessages(tabId) : [];
             const ids = msgs.map(m => m.id);

--- a/details.js
+++ b/details.js
@@ -11,13 +11,13 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   if (!id) {
     try {
-      const tabs = await browser.tabs.query({ active: true, currentWindow: true });
+      const tabs = await browser.tabs.query({ active: true, lastFocusedWindow: true });
       const tabId = tabs[0]?.id;
       const msgs = tabId ? await browser.messageDisplay.getDisplayedMessages(tabId) : [];
       id = msgs[0]?.id;
       logger.aiLog('message id from displayed messages', { debug: true }, id);
       if (!id) {
-        const mailTabs = await browser.mailTabs.query({ active: true, currentWindow: true });
+        const mailTabs = await browser.mailTabs.query({ active: true, lastFocusedWindow: true });
         const mailTabId = mailTabs[0]?.id;
         const selected = mailTabId !== undefined ? await browser.mailTabs.getSelectedMessages(mailTabId) : null;
         id = selected?.messages?.[0]?.id;


### PR DESCRIPTION
## Summary
- resolve message id when Details is opened from preview pane using `lastFocusedWindow`
- update cache clearing logic to respect last focused window

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868f8548e8c832f872b7de0196652a6