### PR TITLE
Add active message retrieval fallback

### DIFF
--- a/background.js
+++ b/background.js
@@ -411,6 +411,19 @@ async function clearCacheForMessages(idsInput) {
             // rethrow so the caller sees the failure
             throw err;
         }
+    } else if (msg?.type === "sortana:getActiveMessage") {
+        try {
+            const displayed = await browser.messageDisplay.getDisplayedMessages();
+            let id = displayed[0]?.id;
+            if (!id) {
+                const selected = await browser.mailTabs.getSelectedMessages();
+                id = selected?.messages?.[0]?.id;
+            }
+            return { id: id ?? null };
+        } catch (e) {
+            logger.aiLog("failed to get active message", { level: 'error' }, e);
+            return { id: null };
+        }
     } else if (msg?.type === "sortana:clearCacheForDisplayed") {
         try {
             const msgs = await browser.messageDisplay.getDisplayedMessages();

--- a/details.js
+++ b/details.js
@@ -20,9 +20,20 @@ document.addEventListener('DOMContentLoaded', async () => {
         logger.aiLog('message id from selected messages', { debug: true }, id);
       }
     } catch (e) {
-      logger.aiLog('failed to determine message id', { level: 'error' }, e);
+      logger.aiLog('failed to determine message id locally', { level: 'error' }, e);
     }
   }
+
+  if (!id) {
+    try {
+      const resp = await browser.runtime.sendMessage({ type: 'sortana:getActiveMessage' });
+      id = resp?.id;
+      logger.aiLog('message id from background', { debug: true }, id);
+    } catch (e) {
+      logger.aiLog('failed to get message id from background', { level: 'error' }, e);
+    }
+  }
+
   if (!id) return;
   try {
     logger.aiLog('requesting message details', {}, id);


### PR DESCRIPTION
## Summary
- add `sortana:getActiveMessage` handling in `background.js`
- request active message from `details.js` if tab APIs fail

## Testing
- `ls test || ls tests || echo 'no tests'`

------
https://chatgpt.com/codex/tasks/task_e_6869f06ca624832fb5f8d1aceca95764