### PR TITLE
Update to manifest v3

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Sortana",
   "version": "2.1.0",
   "default_locale": "en-US",
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "ai-filter@jordanwages",
       "strict_min_version": "128.0",
@@ -18,7 +18,7 @@
     "96": "resources/img/logo96.png",
     "128": "resources/img/logo128.png"
   },
-  "browser_action": {
+  "action": {
     "default_icon": "resources/img/logo32.png"
   },
   "message_display_action": {


### PR DESCRIPTION
## Summary
- switch to manifest_version 3
- rename `applications` block to `browser_specific_settings`
- use the `action` manifest key instead of `browser_action`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a03683d74832fad2c8c5fd40993bd