### PR TITLE
Add host permissions for Sortana

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Sortana requests the following Thunderbird permissions:
 - `accountsRead` – list accounts and folders for move actions.
 - `menus` – add context menu commands.
 - `tabs` – open new tabs and query the active tab.
+- Host permissions (`*://*/*`) – allow network requests to your configured classification service.
 
 ## Thunderbird Add-on Store Disclosures
 

--- a/manifest.json
+++ b/manifest.json
@@ -42,5 +42,8 @@
     "menus",
     "scripting",
     "tabs"
+  ],
+  "host_permissions": [
+    "*://*/*"
   ]
 }


### PR DESCRIPTION
## Summary
- allow network requests by specifying a host permission in `manifest.json`
- document the host permission requirement in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a093172b8832f92d80a1ba768961a