### PR TITLE
Restore automatic panel popup

### DIFF
--- a/background.js
+++ b/background.js
@@ -334,18 +334,6 @@ async function clearCacheForMessages(idsInput) {
             browser.messageDisplayAction.setLabel({ label: "Details" });
         }
 
-        browser.messageDisplayAction.onClicked.addListener(async (tab) => {
-            const header = await browser.messageDisplay.getDisplayedMessage(tab.id);
-            if (!header) {
-                console.warn("[Sortana] no displayed message in tab", tab.id);
-                return;
-            }
-
-            const popupUrl = `${browser.runtime.getURL("details.html")}?mid=${header.id}`;
-
-            await browser.messageDisplayAction.setPopup({ tabId: tab.id, popup: popupUrl });
-            await browser.messageDisplayAction.openPopup({ tabId: tab.id });
-        });
     }
 
     browser.menus.create({
@@ -393,7 +381,7 @@ async function clearCacheForMessages(idsInput) {
                          (info.messageId ? [info.messageId] : []);
             await clearCacheForMessages(ids);
         } else if (info.menuItemId === "view-ai-reason-list" || info.menuItemId === "view-ai-reason-display") {
-            const header = await browser.messageDisplay.getDisplayedMessage(tab.id);
+            const [header] = await browser.messageDisplay.getDisplayedMessages(tab.id);
             if (!header) { return; }
 
             const url = `${browser.runtime.getURL("details.html")}?mid=${header.id}`;

--- a/details.js
+++ b/details.js
@@ -1,22 +1,21 @@
-document.addEventListener('DOMContentLoaded', async () => {
-  const logger = (await import(browser.runtime.getURL('logger.js'))).aiLog;
+document.addEventListener("DOMContentLoaded", async () => {
+  const aiLog = (await import(browser.runtime.getURL("logger.js"))).aiLog;
 
-  const midParam = new URLSearchParams(location.search).get('mid');
-  const messageId = parseInt(midParam, 10);
-
-  if (!messageId) {
-    logger('no ?mid → trying displayedMessage fallback');
-    const openerTabId = (await browser.tabs.getCurrent()).openerTabId;
-    const header = await browser.messageDisplay.getDisplayedMessage(openerTabId);
-    if (!header) {
-      logger('still no message – aborting');
-      return;
-    }
-    loadMessage(header.id);
+  const qMid = parseInt(new URLSearchParams(location.search).get("mid"), 10);
+  if (!isNaN(qMid)) {
+    loadMessage(qMid);
     return;
   }
 
-  loadMessage(messageId);
+  const thisTab   = await browser.tabs.getCurrent();
+  const baseTabId = thisTab.openerTabId ?? thisTab.id;
+  const [header]  = await browser.messageDisplay.getDisplayedMessages(baseTabId);
+
+  if (header) {
+    loadMessage(header.id);
+  } else {
+    aiLog("Details popup: no displayed message found");
+  }
 });
 
 async function loadMessage(id) {

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,8 @@
   "message_display_action": {
     "default_icon": "resources/img/brain.png",
     "default_title": "Details",
-    "default_label": "Details"
+    "default_label": "Details",
+    "default_popup": "details.html"
   },
   "background": { "scripts": [ "background.js" ] },
   "options_ui": {


### PR DESCRIPTION
## Summary
- ensure `default_popup` is set for `message_display_action`
- remove obsolete `messageDisplayAction.onClicked` listener
- fetch displayed message with `getDisplayedMessages`
- handle popup display message lookup reliably

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a2695ee24832f887460c2d5527cf7