### PR TITLE
Backport manifest to version 2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "Sortana",
   "version": "2.1.0",
   "default_locale": "en-US",
-  "browser_specific_settings": {
+  "applications": {
     "gecko": {
       "id": "ai-filter@jordanwages",
       "strict_min_version": "128.0",
@@ -18,7 +18,7 @@
     "96": "resources/img/logo96.png",
     "128": "resources/img/logo128.png"
   },
-  "action": {
+  "browser_action": {
     "default_icon": "resources/img/logo32.png"
   },
   "message_display_action": {
@@ -40,12 +40,8 @@
     "accountsRead",
     "menus",
     "scripting",
-    "tabs"
-  ],
-  "host_permissions": [
+    "tabs",
     "*://*/*"
   ],
-  "content_security_policy": {
-    "extension_pages": "script-src 'self'; object-src 'none'; connect-src 'self' http: https:"
-  }
+  "content_security_policy": "script-src 'self'; object-src 'none'; connect-src 'self' http: https:"
 }


### PR DESCRIPTION
## Summary
- revert manifest.json to WebExtension manifest v2

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a42b91064832f8ad29654b4ee500f