### PR TITLE
Add displayed message retrieval and update details page

### DIFF
--- a/background.js
+++ b/background.js
@@ -501,6 +501,15 @@ async function clearCacheForMessages(idsInput) {
             logger.aiLog("failed to collect details", { level: 'error' }, e);
             return { subject: '', results: [] };
         }
+    } else if (msg?.type === "sortana:getDisplayedMessages") {
+        try {
+            const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+            const messages = await browser.messageDisplay.getDisplayedMessages(tab?.id);
+            return { messages };
+        } catch (e) {
+            logger.aiLog("failed to get displayed messages", { level: 'error' }, e);
+            return { messages: [] };
+        }
     } else if (msg?.type === "sortana:clearCacheForMessage") {
         try {
             await clearCacheForMessages([msg.id]);

--- a/details.html
+++ b/details.html
@@ -15,6 +15,6 @@
       </div>
     </div>
   </section>
-  <script src="details.js"></script>
+  <script type="module" src="details.js"></script>
 </body>
 </html>

--- a/details.js
+++ b/details.js
@@ -1,12 +1,9 @@
-document.addEventListener("DOMContentLoaded", async () => {
-  const aiLog = (await import(browser.runtime.getURL("logger.js"))).aiLog;
+const aiLog = (await import(browser.runtime.getURL("logger.js"))).aiLog;
 
-  const qMid = parseInt(new URLSearchParams(location.search).get("mid"), 10);
-  if (!isNaN(qMid)) {
-    loadMessage(qMid);
-    return;
-  }
-
+const qMid = parseInt(new URLSearchParams(location.search).get("mid"), 10);
+if (!isNaN(qMid)) {
+  loadMessage(qMid);
+} else {
   const thisTab   = await browser.tabs.getCurrent();
   //const baseTabId = thisTab.openerTabId ?? thisTab.id;
   //const [header]  = await browser.messageDisplay.getDisplayedMessages(baseTabId);
@@ -16,7 +13,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   //} else {
   //  aiLog("Details popup: no displayed message found");
   //}
-});
+}
 
 async function loadMessage(id) {
   const storage = (globalThis.messenger ?? browser).storage;


### PR DESCRIPTION
## Summary
- support `sortana:getDisplayedMessages` message in background script
- convert `details.js` to an ES module and remove DOMContentLoaded wrapper
- load `details.js` as a module from `details.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686b56881b5c832faea3cc2f946afa84