### PR TITLE
Fix details popup id retrieval

### DIFF
--- a/details.js
+++ b/details.js
@@ -4,15 +4,14 @@ const qMid = parseInt(new URLSearchParams(location.search).get("mid"), 10);
 if (!isNaN(qMid)) {
   loadMessage(qMid);
 } else {
-  const thisTab   = await browser.tabs.getCurrent();
-  //const baseTabId = thisTab.openerTabId ?? thisTab.id;
-  //const [header]  = await browser.messageDisplay.getDisplayedMessages(baseTabId);
-
-  //if (header) {
-  //  loadMessage(header.id);
-  //} else {
-  //  aiLog("Details popup: no displayed message found");
-  //}
+  const { messages } = await browser.runtime.sendMessage({
+    type: "sortana:getDisplayedMessages",
+  });
+  if (messages && messages[0]) {
+    loadMessage(messages[0].id);
+  } else {
+    aiLog("Details popup: no displayed message found");
+  }
 }
 
 async function loadMessage(id) {


### PR DESCRIPTION
## Summary
- use `sortana:getDisplayedMessages` to find the currently displayed message for the details popup

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686b590b7aa8832f88854ffb6ac41143