### PR TITLE
Fix menu icons for dark theme

### DIFF
--- a/background.js
+++ b/background.js
@@ -377,6 +377,19 @@ async function clearCacheForMessages(idsInput) {
                 refreshMenuIcons();
             }
         });
+
+        if (browser.theme?.onUpdated) {
+            browser.theme.onUpdated.addListener(async () => {
+                if (userTheme === 'auto') {
+                    const theme = await detectSystemTheme();
+                    if (theme !== currentTheme) {
+                        currentTheme = theme;
+                        updateActionIcon();
+                        refreshMenuIcons();
+                    }
+                }
+            });
+        }
     } catch (err) {
         logger.aiLog("failed to load config", { level: 'error' }, err);
     }

--- a/manifest.json
+++ b/manifest.json
@@ -41,6 +41,7 @@
     "accountsRead",
     "menus",
     "scripting",
-    "tabs"
+    "tabs",
+    "theme"
   ]
 }


### PR DESCRIPTION
## Summary
- add `theme` permission so dark mode detection works
- refresh menu icons when Thunderbird theme updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686cbdc236f0832faa6dd2781d97d53a