### PR TITLE
Refactor default AI params

### DIFF
--- a/modules/AiClassifier.js
+++ b/modules/AiClassifier.js
@@ -1,5 +1,6 @@
 "use strict";
 import { aiLog, setDebug } from "../logger.js";
+import { DEFAULT_AI_PARAMS } from "./defaultParams.js";
 
 const storage = (globalThis.messenger ?? globalThis.browser).storage;
 
@@ -33,19 +34,7 @@ let gCustomTemplate = "";
 let gCustomSystemPrompt = DEFAULT_CUSTOM_SYSTEM_PROMPT;
 let gTemplateText = "";
 
-let gAiParams = {
-  max_tokens: 4096,
-  temperature: 0.6,
-  top_p: 0.95,
-  seed: -1,
-  repetition_penalty: 1.0,
-  top_k: 20,
-  min_p: 0,
-  presence_penalty: 0,
-  frequency_penalty: 0,
-  typical_p: 1,
-  tfs: 1,
-};
+let gAiParams = Object.assign({}, DEFAULT_AI_PARAMS);
 
 let gCache = new Map();
 let gCacheLoaded = false;

--- a/modules/defaultParams.js
+++ b/modules/defaultParams.js
@@ -1,0 +1,16 @@
+"use strict";
+
+export const DEFAULT_AI_PARAMS = {
+  max_tokens: 4096,
+  temperature: 0.6,
+  top_p: 0.95,
+  seed: -1,
+  repetition_penalty: 1.0,
+  top_k: 20,
+  min_p: 0,
+  presence_penalty: 0,
+  frequency_penalty: 0,
+  typical_p: 1,
+  tfs: 1,
+};
+

--- a/options/options.js
+++ b/options/options.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', async () => {
     const AiClassifier = await import(browser.runtime.getURL('modules/AiClassifier.js'));
     const dataTransfer = await import(browser.runtime.getURL('options/dataTransfer.js'));
     const { detectSystemTheme } = await import(browser.runtime.getURL('modules/themeUtils.js'));
+    const { DEFAULT_AI_PARAMS } = await import(browser.runtime.getURL('modules/defaultParams.js'));
     const defaults = await storage.local.get([
         'endpoint',
         'templateName',
@@ -66,19 +67,6 @@ document.addEventListener('DOMContentLoaded', async () => {
         markDirty();
         await applyTheme(themeSelect.value);
     });
-    const DEFAULT_AI_PARAMS = {
-        max_tokens: 4096,
-        temperature: 0.6,
-        top_p: 0.95,
-        seed: -1,
-        repetition_penalty: 1.0,
-        top_k: 20,
-        min_p: 0,
-        presence_penalty: 0,
-        frequency_penalty: 0,
-        typical_p: 1,
-        tfs: 1
-    };
     document.getElementById('endpoint').value = defaults.endpoint || 'http://127.0.0.1:5000/v1/completions';
 
     const templates = {


### PR DESCRIPTION
## Summary
- add `modules/defaultParams.js` with shared DEFAULT_AI_PARAMS
- use DEFAULT_AI_PARAMS in AiClassifier
- use DEFAULT_AI_PARAMS in options page script

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686d94218280832fa96457b96f8499c9