### PR TITLE
Improve rule option button clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,9 @@ Sortana is implemented entirely with standard WebExtension scripts—no custom e
    reorder them, check *Only apply to unread messages* to skip read mail,
    set optional minimum or maximum message age limits, select the accounts or
  folders a rule should apply to. Use the
-  slashed-circle/check button to disable or re-enable a rule, and
-  check *Stop after match* to halt further processing. Forward and reply actions
+ slashed-circle/check button to disable or re-enable a rule. The small
+ circle buttons for optional conditions show a filled dot when active, and
+ check *Stop after match* to halt further processing. Forward and reply actions
    open a compose window using the account that received the message.
 3. Save your settings. New mail will be evaluated automatically using the
    configured rules.

--- a/options/options.js
+++ b/options/options.js
@@ -286,12 +286,18 @@ document.addEventListener('DOMContentLoaded', async () => {
         const btn = document.createElement('button');
         btn.type = 'button';
         btn.className = 'button is-small is-light';
-        btn.textContent = label;
+        const icon = document.createElement('img');
+        icon.width = 16;
+        icon.height = 16;
+        icon.className = 'mr-1';
+        btn.appendChild(icon);
+        btn.append(label);
 
         let active = checkbox ? checkbox.checked : sectionEl && !sectionEl.classList.contains('is-hidden');
 
         function update() {
-            btn.classList.toggle('is-info', active);
+            btn.classList.toggle('is-active', active);
+            icon.src = browser.runtime.getURL(`resources/svg/${active ? 'circledot' : 'circle'}.svg`);
             if (sectionEl) sectionEl.classList.toggle('is-hidden', !active);
             if (checkbox) checkbox.checked = active;
         }


### PR DESCRIPTION
## Summary
- show an icon for each rule condition button
- toggle Bulma `is-active` class when selected
- document the filled-dot icon behavior

## Testing
- `node -c options/options.js`

------
https://chatgpt.com/codex/tasks/task_e_68773a33c63c832fbc3f02c67bf5dcc6